### PR TITLE
Add SDuration package with text, JSON, and SQL serialization

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,2 @@
+sduration
+SDuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Check go.mod and go.sum
+      - name: Check go.mod
         run: |
           go mod tidy
-          git diff --exit-code go.mod go.sum || (echo "Please run 'go mod tidy' and commit changes" && exit 1)
+          git diff --exit-code go.mod || (echo "Please run 'go mod tidy' and commit changes to go.mod" && exit 1)
 
       - name: Check format
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23.0', '1.24.0']
+        platform:
+          - os: ubuntu-latest
+            arch: "386"
+          - os: ubuntu-latest
+            arch: amd64
+          - os: macos-13
+            arch: amd64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
+            arch: "386"
+          - os: windows-latest
+            arch: amd64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt
+          flags: unittests
+          fail_ci_if_error: false
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+          check-latest: true
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m
+
+  validate:
+    name: Validate Go modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+          check-latest: true
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Check go.mod and go.sum
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum || (echo "Please run 'go mod tidy' and commit changes" && exit 1)
+
+      - name: Check format
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "Go files must be formatted with gofmt. Please run:"
+            echo "  gofmt -l ."
+            exit 1
+          fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+#    - copyloopvar
+    - exhaustive
+    - goconst
+    - gofmt
+    - gocyclo
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    - wsl
+
+run:
+  issues-exit-code: 1
+
+issues:
+  exclude-files:
+    - "^.*?_test\\.go$"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gosmos-space/sduration
+
+go 1.18

--- a/json.go
+++ b/json.go
@@ -1,0 +1,32 @@
+package sduration
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// MarshalJSON implements the json.Marshaler interface.
+// It returns the duration as a string in JSON format.
+func (d SDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Duration().String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It expects a string in the format that time.ParseDuration can handle.
+func (d *SDuration) UnmarshalJSON(bytes []byte) error {
+	var s string
+
+	if err := json.Unmarshal(bytes, &s); err != nil {
+		return err
+	}
+
+	duration, err := time.ParseDuration(s)
+
+	if err != nil {
+		return err
+	}
+
+	*d = SDuration(duration)
+
+	return nil
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,327 @@
+package sduration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+		want     string
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+			want:     `"0s"`,
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+			want:     `"5s"`,
+		},
+		{
+			name:     "minutes",
+			duration: SDuration(10 * time.Minute),
+			want:     `"10m0s"`,
+		},
+		{
+			name:     "hours",
+			duration: SDuration(2 * time.Hour),
+			want:     `"2h0m0s"`,
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			want:     `"1h30m45s"`,
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+			want:     `"-30s"`,
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+			want:     `"250ms"`,
+		},
+		{
+			name:     "microseconds",
+			duration: SDuration(500 * time.Microsecond),
+			want:     `"500µs"`,
+		},
+		{
+			name:     "nanoseconds",
+			duration: SDuration(50 * time.Nanosecond),
+			want:     `"50ns"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := tt.duration.MarshalJSON()
+				if err != nil {
+					t.Errorf("MarshalJSON() error = %v", err)
+					return
+				}
+
+				if string(got) != tt.want {
+					t.Errorf("MarshalJSON() got = %v, want %v", string(got), tt.want)
+				}
+			},
+		)
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    SDuration
+		wantErr bool
+	}{
+		{
+			name:    "seconds",
+			json:    `"5s"`,
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "minutes",
+			json:    `"10m"`,
+			want:    SDuration(10 * time.Minute),
+			wantErr: false,
+		},
+		{
+			name:    "hours",
+			json:    `"2h"`,
+			want:    SDuration(2 * time.Hour),
+			wantErr: false,
+		},
+		{
+			name:    "complex",
+			json:    `"1h30m45s"`,
+			want:    SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "negative",
+			json:    `"-30s"`,
+			want:    SDuration(-30 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "milliseconds",
+			json:    `"250ms"`,
+			want:    SDuration(250 * time.Millisecond),
+			wantErr: false,
+		},
+		{
+			name:    "microseconds",
+			json:    `"500µs"`,
+			want:    SDuration(500 * time.Microsecond),
+			wantErr: false,
+		},
+		{
+			name:    "nanoseconds",
+			json:    `"50ns"`,
+			want:    SDuration(50 * time.Nanosecond),
+			wantErr: false,
+		},
+		{
+			name:    "zero",
+			json:    `"0s"`,
+			want:    SDuration(0),
+			wantErr: false,
+		},
+		{
+			name:    "empty string",
+			json:    `""`,
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			json:    `"not a duration"`,
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "missing unit",
+			json:    `"42"`,
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "missing quotes",
+			json:    `5s`,
+			want:    SDuration(0),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				var d SDuration
+				err := d.UnmarshalJSON([]byte(tt.json))
+
+				if (err != nil) != tt.wantErr {
+					t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
+				if !tt.wantErr && d != tt.want {
+					t.Errorf("UnmarshalJSON() got = %v, want %v", d, tt.want)
+				}
+			},
+		)
+	}
+}
+
+// TestJSONStructMarshalUnmarshal tests the complete cycle of marshaling and
+// unmarshaling SDuration within a struct in a JSON context
+func TestJSONStructMarshalUnmarshal(t *testing.T) {
+	type Config struct {
+		Timeout SDuration `json:"timeout"`
+		Retry   SDuration `json:"retry"`
+	}
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name: "basic_durations",
+			config: Config{
+				Timeout: SDuration(30 * time.Second),
+				Retry:   SDuration(5 * time.Minute),
+			},
+		},
+		{
+			name: "complex_durations",
+			config: Config{
+				Timeout: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+				Retry:   SDuration(250 * time.Millisecond),
+			},
+		},
+		{
+			name: "zero_values",
+			config: Config{
+				Timeout: SDuration(0),
+				Retry:   SDuration(0),
+			},
+		},
+		{
+			name: "negative_values",
+			config: Config{
+				Timeout: SDuration(-10 * time.Second),
+				Retry:   SDuration(-500 * time.Millisecond),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				// Marshal to JSON
+				jsonData, err := json.Marshal(tt.config)
+				if err != nil {
+					t.Errorf("json.Marshal() error = %v", err)
+					return
+				}
+
+				// Unmarshal back
+				var decoded Config
+				err = json.Unmarshal(jsonData, &decoded)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				// Compare
+				if decoded.Timeout != tt.config.Timeout {
+					t.Errorf(
+						"Timeout field mismatch: got = %v, want %v",
+						decoded.Timeout.Duration(), tt.config.Timeout.Duration(),
+					)
+				}
+				if decoded.Retry != tt.config.Retry {
+					t.Errorf(
+						"Retry field mismatch: got = %v, want %v",
+						decoded.Retry.Duration(), tt.config.Retry.Duration(),
+					)
+				}
+			},
+		)
+	}
+}
+
+// TestJSONRoundTrip tests marshaling and unmarshaling a single SDuration value directly
+func TestJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+		},
+		{
+			name:     "microseconds",
+			duration: SDuration(500 * time.Microsecond),
+		},
+		{
+			name:     "nanoseconds",
+			duration: SDuration(50 * time.Nanosecond),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				// Marshal the duration to JSON
+				jsonData, err := json.Marshal(tt.duration)
+				if err != nil {
+					t.Errorf("json.Marshal() error = %v", err)
+					return
+				}
+
+				// Unmarshal the JSON back to a duration
+				var unmarshaled SDuration
+				err = json.Unmarshal(jsonData, &unmarshaled)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				// Compare the original and round-tripped durations
+				if unmarshaled != tt.duration {
+					t.Errorf(
+						"Round-trip: got = %v, want %v",
+						time.Duration(unmarshaled), time.Duration(tt.duration),
+					)
+				}
+			},
+		)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,228 @@
+# sduration
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/gosmos-space/sduration.svg)](https://pkg.go.dev/github.com/gosmos-space/sduration)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gosmos-space/sduration)](https://goreportcard.com/report/github.com/gosmos-space/sduration)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A Go package that provides a string-serializable duration type that wraps `time.Duration`.
+
+## Overview
+
+The `sduration` package implements a custom duration type (`SDuration`) that wraps the standard `time.Duration` with serialization capabilities. It enables:
+
+- Text marshaling/unmarshaling (for encoding like YAML, TOML)
+- JSON marshaling/unmarshaling
+- sql package compatibility for database storage
+- Human-readable duration strings in configs and data formats
+
+## Installation
+
+```bash
+go get github.com/gosmos-space/sduration
+```
+
+## Usage
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "time"
+    
+    "github.com/gosmos-space/sduration"
+)
+
+func main() {
+    // Create an SDuration from time.Duration
+    d := sduration.SDuration(5 * time.Second)
+    
+    // Convert back to time.Duration
+    timeDur := d.Duration()
+    
+    fmt.Printf("Duration: %v\n", timeDur) // Output: Duration: 5s
+}
+```
+
+### With Text Marshaling (YAML, TOML)
+
+```go
+package main
+
+import (
+    "fmt"
+    "encoding/json"
+    "gopkg.in/yaml.v3"
+    
+    "github.com/gosmos-space/sduration"
+)
+
+type Config struct {
+    Timeout sduration.SDuration `yaml:"timeout" json:"timeout"`
+    Retry   sduration.SDuration `yaml:"retry" json:"retry"`
+}
+
+func main() {
+    // Parse config from YAML
+    yamlData := []byte(`
+timeout: 30s
+retry: 5m
+`)
+    
+    var config Config
+    if err := yaml.Unmarshal(yamlData, &config); err != nil {
+        panic(err)
+    }
+    
+    fmt.Printf("Timeout: %v\n", config.Timeout.Duration())
+    fmt.Printf("Retry: %v\n", config.Retry.Duration())
+    
+    // Convert back to YAML
+    out, _ := yaml.Marshal(config)
+    fmt.Println(string(out))
+}
+```
+
+### With JSON
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "time"
+    
+    "github.com/gosmos-space/sduration"
+)
+
+type APIConfig struct {
+    RequestTimeout sduration.SDuration `json:"requestTimeout"`
+    SessionTTL     sduration.SDuration `json:"sessionTTL"`
+}
+
+func main() {
+    // Create a config
+    config := APIConfig{
+        RequestTimeout: sduration.SDuration(30 * time.Second),
+        SessionTTL:     sduration.SDuration(24 * time.Hour),
+    }
+    
+    // Marshal to JSON
+    jsonData, _ := json.Marshal(config)
+    fmt.Println(string(jsonData))
+    // Output: {"requestTimeout":"30s","sessionTTL":"24h0m0s"}
+    
+    // Unmarshal from JSON
+    jsonInput := []byte(`{"requestTimeout":"45s","sessionTTL":"12h"}`)
+    var newConfig APIConfig
+    
+    if err := json.Unmarshal(jsonInput, &newConfig); err != nil {
+        panic(err)
+    }
+    
+    fmt.Printf("Request Timeout: %v\n", newConfig.RequestTimeout.Duration())
+    fmt.Printf("Session TTL: %v\n", newConfig.SessionTTL.Duration())
+}
+```
+
+### With SQL Databases
+
+```go
+package main
+
+import (
+    "database/sql"
+    "fmt"
+    "log"
+    "time"
+    
+    "github.com/gosmos-space/sduration"
+    _ "github.com/mattn/go-sqlite3"
+)
+
+type Job struct {
+    ID       int
+    Timeout  sduration.SDuration
+    Interval sduration.SDuration
+}
+
+func main() {
+    // Open database connection
+    db, err := sql.Open("sqlite3", ":memory:")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
+    
+    // Create table
+    _, err = db.Exec(`CREATE TABLE jobs (
+        id INTEGER PRIMARY KEY,
+        timeout TEXT,
+        interval TEXT
+    )`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    // Insert job with durations
+    job := Job{
+        ID:       1,
+        Timeout:  sduration.SDuration(30 * time.Second),
+        Interval: sduration.SDuration(5 * time.Minute),
+    }
+    
+    _, err = db.Exec(
+        "INSERT INTO jobs (id, timeout, interval) VALUES (?, ?, ?)",
+        job.ID, job.Timeout, job.Interval,
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    // Query the data back
+    var retrievedJob Job
+    err = db.QueryRow("SELECT id, timeout, interval FROM jobs WHERE id = ?", 1).Scan(
+        &retrievedJob.ID, &retrievedJob.Timeout, &retrievedJob.Interval,
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    fmt.Printf("Job ID: %d\n", retrievedJob.ID)
+    fmt.Printf("Timeout: %v\n", retrievedJob.Timeout.Duration())
+    fmt.Printf("Interval: %v\n", retrievedJob.Interval.Duration())
+}
+```
+
+## Features
+
+- **String Serialization**: Durations are stored as human-readable strings (e.g., "5m30s") rather than nanosecond integers
+- **Compatible with time.Duration**: Easy conversion between SDuration and time.Duration
+- **Supports JSON**: Properly marshals/unmarshals to/from JSON as strings with units
+- **Supports Text Encoding**: Works with text-based encodings like YAML and TOML
+- **SQL Database Support**: Implements `sql.Scanner` and `driver.Valuer` for database storage
+- **Type Safety**: Maintains type safety while ensuring serialization works correctly
+
+## Supported Formats
+
+SDuration supports all the same duration formats as `time.ParseDuration`:
+
+- "ns" - nanoseconds
+- "us" or "µs" - microseconds
+- "ms" - milliseconds
+- "s" - seconds
+- "m" - minutes
+- "h" - hours
+
+Examples: "300ms", "1.5h", "2h45m", "-30s"
+
+## License
+
+MIT License
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/sduration.go
+++ b/sduration.go
@@ -1,0 +1,11 @@
+package sduration
+
+import "time"
+
+// SDuration is a wrapper around time.Duration that allows for JSON/Text/SQL marshalling and unmarshalling.
+type SDuration time.Duration
+
+// Duration returns the time.Duration value of the SDuration.
+func (d SDuration) Duration() time.Duration {
+	return time.Duration(d)
+}

--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,65 @@
+package sduration
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+)
+
+// Value implements the driver.Valuer interface.
+// This method returns a driver.Value from the SDuration.
+// It will be stored in the database as a string.
+func (d SDuration) Value() (driver.Value, error) {
+	return d.Duration().String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// This method scans a value from the database driver and
+// attempts to convert it to an SDuration.
+func (d *SDuration) Scan(src interface{}) error {
+	if src == nil {
+		*d = SDuration(0)
+		return nil
+	}
+
+	// Handle different types that might come from the database
+	switch v := src.(type) {
+	case string:
+		// Parse the duration string
+		duration, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("failed to parse duration from string '%s': %w", v, err)
+		}
+
+		*d = SDuration(duration)
+
+		return nil
+
+	case []byte:
+		// Parse the duration from bytes (common in SQL drivers)
+		duration, err := time.ParseDuration(string(v))
+
+		if err != nil {
+			return fmt.Errorf("failed to parse duration from bytes '%s': %w", string(v), err)
+		}
+
+		*d = SDuration(duration)
+
+		return nil
+
+	case int64:
+		// Handle the case where the duration is stored as nanoseconds
+		*d = SDuration(v)
+
+		return nil
+
+	case float64:
+		// Handle the case where the duration is stored as a float
+		*d = SDuration(time.Duration(v))
+
+		return nil
+
+	default:
+		return fmt.Errorf("cannot scan type %T into SDuration", src)
+	}
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,204 @@
+package sduration
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+)
+
+func TestValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+		want     string
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+			want:     "0s",
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+			want:     "5s",
+		},
+		{
+			name:     "minutes",
+			duration: SDuration(10 * time.Minute),
+			want:     "10m0s",
+		},
+		{
+			name:     "hours",
+			duration: SDuration(2 * time.Hour),
+			want:     "2h0m0s",
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			want:     "1h30m45s",
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+			want:     "-30s",
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+			want:     "250ms",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := tt.duration.Value()
+				if err != nil {
+					t.Errorf("Value() error = %v", err)
+					return
+				}
+
+				if got != tt.want {
+					t.Errorf("Value() got = %v, want %v", got, tt.want)
+				}
+
+				// Verify the returned type implements driver.Value
+				var _ driver.Value = got
+			},
+		)
+	}
+}
+
+func TestScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     interface{}
+		want    SDuration
+		wantErr bool
+	}{
+		{
+			name:    "string",
+			src:     "5s",
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "string_complex",
+			src:     "1h30m45s",
+			want:    SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "bytes",
+			src:     []byte("5s"),
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "int64",
+			src:     int64(5 * time.Second),
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "float64",
+			src:     float64(5 * time.Second),
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "nil",
+			src:     nil,
+			want:    SDuration(0),
+			wantErr: false,
+		},
+		{
+			name:    "invalid_string",
+			src:     "not_a_duration",
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "invalid_type",
+			src:     struct{}{},
+			want:    SDuration(0),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				var d SDuration
+				err := d.Scan(tt.src)
+
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Scan() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
+				if !tt.wantErr && d != tt.want {
+					t.Errorf("Scan() got = %v, want %v", d.Duration(), tt.want.Duration())
+				}
+			},
+		)
+	}
+}
+
+// TestSQLRoundTrip tests the full roundtrip of Value -> Scan
+func TestSQLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				// Value
+				val, err := tt.duration.Value()
+				if err != nil {
+					t.Errorf("Value() error = %v", err)
+					return
+				}
+
+				// Scan
+				var scanned SDuration
+				err = scanned.Scan(val)
+				if err != nil {
+					t.Errorf("Scan() error = %v", err)
+					return
+				}
+
+				// Compare
+				if scanned != tt.duration {
+					t.Errorf(
+						"Round-trip: got = %v, want %v",
+						scanned.Duration(), tt.duration.Duration(),
+					)
+				}
+			},
+		)
+	}
+}

--- a/text.go
+++ b/text.go
@@ -1,0 +1,19 @@
+package sduration
+
+import "time"
+
+func (d *SDuration) UnmarshalText(text []byte) error {
+	duration, err := time.ParseDuration(string(text))
+
+	if err != nil {
+		return err
+	}
+
+	*d = SDuration(duration)
+
+	return nil
+}
+
+func (d SDuration) MarshalText() (text []byte, err error) {
+	return []byte(d.Duration().String()), nil
+}

--- a/text_test.go
+++ b/text_test.go
@@ -1,0 +1,243 @@
+package sduration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUnmarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		want    SDuration
+		wantErr bool
+	}{
+		{
+			name:    "seconds",
+			text:    "5s",
+			want:    SDuration(5 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "minutes",
+			text:    "10m",
+			want:    SDuration(10 * time.Minute),
+			wantErr: false,
+		},
+		{
+			name:    "hours",
+			text:    "2h",
+			want:    SDuration(2 * time.Hour),
+			wantErr: false,
+		},
+		{
+			name:    "complex",
+			text:    "1h30m45s",
+			want:    SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "negative",
+			text:    "-30s",
+			want:    SDuration(-30 * time.Second),
+			wantErr: false,
+		},
+		{
+			name:    "milliseconds",
+			text:    "250ms",
+			want:    SDuration(250 * time.Millisecond),
+			wantErr: false,
+		},
+		{
+			name:    "microseconds",
+			text:    "500µs",
+			want:    SDuration(500 * time.Microsecond),
+			wantErr: false,
+		},
+		{
+			name:    "nanoseconds",
+			text:    "50ns",
+			want:    SDuration(50 * time.Nanosecond),
+			wantErr: false,
+		},
+		{
+			name:    "zero",
+			text:    "0s",
+			want:    SDuration(0),
+			wantErr: false,
+		},
+		{
+			name:    "empty string",
+			text:    "",
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			text:    "not a duration",
+			want:    SDuration(0),
+			wantErr: true,
+		},
+		{
+			name:    "missing unit",
+			text:    "42",
+			want:    SDuration(0),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				var d SDuration
+				err := d.UnmarshalText([]byte(tt.text))
+
+				if (err != nil) != tt.wantErr {
+					t.Errorf("UnmarshalText() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
+				if !tt.wantErr && d != tt.want {
+					t.Errorf("UnmarshalText() got = %v, want %v", d, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+		want     string
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+			want:     "0s",
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+			want:     "5s",
+		},
+		{
+			name:     "minutes",
+			duration: SDuration(10 * time.Minute),
+			want:     "10m0s",
+		},
+		{
+			name:     "hours",
+			duration: SDuration(2 * time.Hour),
+			want:     "2h0m0s",
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+			want:     "1h30m45s",
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+			want:     "-30s",
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+			want:     "250ms",
+		},
+		{
+			name:     "microseconds",
+			duration: SDuration(500 * time.Microsecond),
+			want:     "500µs",
+		},
+		{
+			name:     "nanoseconds",
+			duration: SDuration(50 * time.Nanosecond),
+			want:     "50ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := tt.duration.MarshalText()
+				if err != nil {
+					t.Errorf("MarshalText() error = %v", err)
+					return
+				}
+
+				if string(got) != tt.want {
+					t.Errorf("MarshalText() got = %v, want %v", string(got), tt.want)
+				}
+			},
+		)
+	}
+}
+
+// TestRoundTripMarshalUnmarshal tests the complete cycle of marshaling
+// and then unmarshaling to ensure consistency
+func TestRoundTripMarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration SDuration
+	}{
+		{
+			name:     "zero",
+			duration: SDuration(0),
+		},
+		{
+			name:     "seconds",
+			duration: SDuration(5 * time.Second),
+		},
+		{
+			name:     "complex",
+			duration: SDuration(1*time.Hour + 30*time.Minute + 45*time.Second),
+		},
+		{
+			name:     "negative",
+			duration: SDuration(-30 * time.Second),
+		},
+		{
+			name:     "milliseconds",
+			duration: SDuration(250 * time.Millisecond),
+		},
+		{
+			name:     "microseconds",
+			duration: SDuration(500 * time.Microsecond),
+		},
+		{
+			name:     "nanoseconds",
+			duration: SDuration(50 * time.Nanosecond),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				// Marshal the duration to text
+				text, err := tt.duration.MarshalText()
+				if err != nil {
+					t.Errorf("MarshalText() error = %v", err)
+					return
+				}
+
+				// Unmarshal the text back to a duration
+				var unmarshaled SDuration
+				err = unmarshaled.UnmarshalText(text)
+				if err != nil {
+					t.Errorf("UnmarshalText() error = %v", err)
+					return
+				}
+
+				// Compare the original and round-tripped durations
+				if unmarshaled != tt.duration {
+					t.Errorf(
+						"Round-trip: got = %v, want %v",
+						time.Duration(unmarshaled), time.Duration(tt.duration),
+					)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
This commit introduces the SDuration package, which provides a type-safe wrapper around Go's time.Duration with support for string-based serialization.

Features include:
- Text marshaling/unmarshaling for YAML, TOML, and other text-based formats
- JSON marshaling/unmarshaling with human-readable duration strings
- SQL database integration via sql.Scanner and driver.Valuer interfaces
- Comprehensive test suite for all serialization methods
- GitHub Actions CI workflow for quality assurance

SDuration makes working with durations in configuration files and databases more intuitive by preserving human-readable formats (like "30s", "5m", "2h") instead of nanosecond integers.

Minimum Go version: 1.18